### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/XDPXI/xdpxi/security/code-scanning/2](https://github.com/XDPXI/xdpxi/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only involves reading repository contents (e.g., checking out the code and installing dependencies), we will set `contents: read` as the minimal required permission. This ensures the workflow has the least privileges necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
